### PR TITLE
Collision fix

### DIFF
--- a/src/toji-tris.js
+++ b/src/toji-tris.js
@@ -158,7 +158,8 @@ function traceSphereTriangle (a, b, trace) {
     vec2.add(planeIntersect, v, planeIntersect)
 
     // Is that point inside the triangle?
-    if (segpoint(planeIntersect, ta, tb)) {
+    const epsilon = 0
+    if (segpoint(planeIntersect, ta, tb, epsilon)) {
       trace.setCollision(t0, planeIntersect)
       // Collisions against the face will always be closer than vertex or edge collisions
       // so we can stop checking now.

--- a/src/toji-tris.js
+++ b/src/toji-tris.js
@@ -1,8 +1,9 @@
 // from https://github.com/kevzettler/gl-swept-sphere-triangle
-import { clamp, segpoint, vec2 } from './deps.js'
+import { clamp, vec2 } from './deps.js'
 import TraceInfo       from './TraceInfo.js'
 import getLowestRoot   from './get-lowest-root.js'
 import lineNormal      from './segment-normal.js'
+import segpoint        from 'https://cdn.jsdelivr.net/gh/tmpvar/segseg@8cca1e0/segpoint.js'
 
 
 const ta = vec2.create()

--- a/src/toji-tris.js
+++ b/src/toji-tris.js
@@ -1,5 +1,5 @@
 // from https://github.com/kevzettler/gl-swept-sphere-triangle
-import { clamp, vec2 } from './deps.js'
+import { clamp, segpoint, vec2 } from './deps.js'
 import TraceInfo       from './TraceInfo.js'
 import getLowestRoot   from './get-lowest-root.js'
 import lineNormal      from './segment-normal.js'
@@ -149,11 +149,6 @@ function traceSphereTriangle (a, b, trace) {
   // during which it intersects with the triangle plane.
   // Collisions cannot happen outside that range.
 
-
-  // this was leftover from Toji's 3d collision code. I don't think
-  // we need this for the 2d case, so I disabled it.
-
-  /*
   // Check for collision againt the triangle face:
   if (!embedded) {
     // Calculate the intersection point with the plane
@@ -169,7 +164,6 @@ function traceSphereTriangle (a, b, trace) {
       return
     }
   }
-  */
 
   const velSqrLen = vec2.squaredLength(vel)
   let t = trace.t

--- a/test/trace-sphere-triangle.js
+++ b/test/trace-sphere-triangle.js
@@ -18,3 +18,18 @@ assert.equal(ti.collision, true)
 assert.equal(ti.t, 0.875)
 assert.deepEqual(ti.intersectTriNorm, [ -1, 0 ])
 assert.deepEqual(ti.intersectPoint, [ 128, 32 ])
+
+
+// when the sphere is 0 distance from a line segment, collide with it
+{
+	const start = [ 112, 64 ]
+	const end = [ 140, 64 ]
+	const radius = 16
+
+	const ti = new toji.TraceInfo()
+	ti.resetTrace(start, end, radius)
+
+	toji.traceSphereTriangle(a, b, ti);
+	assert.equal(ti.collision, true)
+	assert.equal(ti.t, 0.0)
+}


### PR DESCRIPTION
When a sphere is 0 distance from a line segment, it was failing to detect the collision. re-enabling this case from Toji's original code solves the problem.